### PR TITLE
No need to encode PrivateTokenAuth in base64url

### DIFF
--- a/draft-ietf-moq-privacy-pass-auth.md
+++ b/draft-ietf-moq-privacy-pass-auth.md
@@ -400,7 +400,7 @@ SETUP {
     Parameters = [
         {
             Type = AUTHORIZATION,
-            Value = base64url(PrivateTokenAuth)
+            Value = PrivateTokenAuth
         }
     ]
 }
@@ -423,7 +423,7 @@ SUBSCRIBE {
     Parameters = [
         {
             Type = AUTHORIZATION,
-            Value = base64url(PrivateTokenAuth)
+            Value = PrivateTokenAuth
         }
     ]
 }


### PR DESCRIPTION
[AUTHORIZATION](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16#section-9.3.1.5) is a key value pair with an odd value = 0x3, which means its value is a sequence of [raw bytes](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-16#name-key-value-pair-structure).

On the contrary to an HTTP header which has to be encoded, this is not the case here and we can use the raw value directly, which is more consistent with the byte definication of KV pair.